### PR TITLE
Bump default CLI version to 0.10.8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: 'Version of Markdown Figma CLI to install'
     required: false
-    default: 0.10.7
+    default: 0.10.8
 
 runs:
   using: node20


### PR DESCRIPTION
The 0.10.8 release of markdown-figma includes a fix to the HTML parsing path that finds markdown image syntax (e.g. ![alt](images/foo.png)) embedded inside HTML blocks like <table>...</table>. Without the bump this action keeps installing 0.10.7 by default, so consumers using --parse-html on docs with HTML wrappers continue to see those images reported as Not used.